### PR TITLE
Build was broken, because Makefile still had chameleon references.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ include setup.mk
 
 VENVDIR := venv-$(shell uname -s | tr '[:upper:]' '[:lower:]')
 
-.PHONY: $(DIRS) $(DIRS_CLEAN) $(DIRS_FLAKE8) flake8 docker-base voltha chameleon ofagent podder netconf shovel onos
+.PHONY: $(DIRS) $(DIRS_CLEAN) $(DIRS_FLAKE8) flake8 docker-base voltha ofagent podder netconf shovel onos
 
 default: build
 
@@ -76,19 +76,13 @@ help:
 
 build: protos containers
 
-containers: docker-base voltha chameleon ofagent podder netconf shovel onos tester
+containers: docker-base voltha ofagent podder netconf shovel onos tester
 
 docker-base:
 	docker build -t cord/voltha-base -f docker/Dockerfile.base .
 
 voltha:
 	docker build -t cord/voltha -f docker/Dockerfile.voltha .
-
-chameleon:
-	mkdir tmp.chameleon
-	cp -R chameleon/* tmp.chameleon
-	docker build -t cord/chameleon -f docker/Dockerfile.chameleon .
-	rm -rf tmp.chameleon
 
 ofagent:
 	docker build -t cord/ofagent -f docker/Dockerfile.ofagent .
@@ -110,7 +104,6 @@ tester:
 
 protos:
 	make -C voltha/protos
-	make -C chameleon/protos
 	make -C ofagent/protos
 	make -C netconf/protos
 
@@ -165,7 +158,7 @@ utest-with-coverage: venv protos
 	@ echo "Executing all unit tests and producing coverage results"
 	. ${VENVDIR}/bin/activate && \
         for d in $$(find ./tests/utests -depth -type d); do echo $$d:; \
-	nosetests --with-xcoverage --with-xunit --cover-package=voltha,common,ofagent,chameleon $$d; done
+	nosetests --with-xcoverage --with-xunit --cover-package=voltha,common,ofagent $$d; done
 
 itest: venv run-as-root-tests
 	@ echo "Executing all integration tests"


### PR DESCRIPTION
As per this commit:

```
commit 50ec793f00db2c21b022b531eaca6e13c0136fc3
Author: alshabib <alshabibi.ali@gmail.com>
Date:   Tue Jan 31 15:28:32 2017 -0800

removing chameleon from voltha

Change-Id: Ied7a0eff178c6a23c01a1e10747f872c8976a5bb
```

I think there should be no references to chameleon in the Makefile.

In the repo there are still some tests for chameleon, may be those
should be deleted also.



With the current Makefile if you try to compile you get the following error:
```
(venv-linux) root@vOLTHA:/home/sysadmin/voltha# make
Makefile:85: warning: overriding recipe for target 'voltha'
Makefile:45: warning: ignoring old recipe for target 'voltha'
make -C voltha/protos
make[1]: Nothing to be done for 'default'.
make -C chameleon/protos
make[1]: *** chameleon/protos: No such file or directory.  Stop.
Makefile:112: recipe for target 'protos' failed
make: *** [protos] Error 2
```

Some other people is having the same problems:
https://groups.google.com/a/opencord.org/forum/#!msg/cord-dev/Q3XC0tfpefo/jBOP3x_5CgAJ